### PR TITLE
change calls of int() to be int(float()) when strings involved

### DIFF
--- a/src/rrr_cpl_riv_lsm_lnk.py
+++ b/src/rrr_cpl_riv_lsm_lnk.py
@@ -95,7 +95,7 @@ IV_riv_tot_id=[]
 with open(rrr_con_file) as csv_file:
      reader=csv.reader(csv_file,dialect='excel',quoting=csv.QUOTE_NONNUMERIC)
      for row in reader:
-          IV_riv_tot_id.append(int(row[0]))
+          IV_riv_tot_id.append(int(float(row[0])))
 IS_riv_tot=len(IV_riv_tot_id)
 print('- The number of river reaches is: '+str(IS_riv_tot))
 
@@ -111,7 +111,7 @@ ZV_cat_lat=[]
 with open(rrr_cat_file) as csv_file:
      reader=csv.reader(csv_file,dialect='excel',quoting=csv.QUOTE_NONNUMERIC)
      for row in reader:
-          IV_cat_tot_id.append(int(row[0]))
+          IV_cat_tot_id.append(int(float(row[0])))
           ZV_cat_sqkm.append(row[1])
           ZV_cat_lon.append(row[2])
           ZV_cat_lat.append(row[3])

--- a/src/rrr_cpl_riv_lsm_vol.py
+++ b/src/rrr_cpl_riv_lsm_vol.py
@@ -114,7 +114,7 @@ IV_riv_tot_id1=[]
 with open(rrr_con_file) as csv_file:
      reader=csv.reader(csv_file,dialect='excel',quoting=csv.QUOTE_NONNUMERIC)
      for row in reader:
-          IV_riv_tot_id1.append(int(row[0]))
+          IV_riv_tot_id1.append(int(float(row[0])))
 IS_riv_tot1=len(IV_riv_tot_id1)
 print('  . The number of river reaches in connectivity file is: '              \
            +str(IS_riv_tot1))
@@ -130,7 +130,7 @@ ZV_lat=[]
 with open(rrr_crd_file) as csv_file:
      reader=csv.reader(csv_file,dialect='excel',quoting=csv.QUOTE_NONNUMERIC)
      for row in reader:
-          IV_riv_tot_id2.append(int(row[0]))
+          IV_riv_tot_id2.append(int(float(row[0])))
           ZV_lon.append(row[1])
           ZV_lat.append(row[2])
 IS_riv_tot2=len(IV_riv_tot_id2)
@@ -190,10 +190,10 @@ IV_riv_j_index=[]
 with open(rrr_cpl_file) as csv_file:
      reader=csv.reader(csv_file,dialect='excel',quoting=csv.QUOTE_NONNUMERIC)
      for row in reader:
-          IV_riv_tot_id3.append(int(row[0]))
+          IV_riv_tot_id3.append(int(float(row[0])))
           ZV_riv_sqkm.append(row[1])
-          IV_riv_i_index.append(int(row[2]))
-          IV_riv_j_index.append(int(row[3]))
+          IV_riv_i_index.append(int(float(row[2])))
+          IV_riv_j_index.append(int(float(row[3])))
 IS_riv_tot3=len(IV_riv_tot_id3)
 print('  . The number of river reaches in coupling file is: '+str(IS_riv_tot3))
 

--- a/src/rrr_riv_bas_gen_one_nhdplus.py
+++ b/src/rrr_riv_bas_gen_one_nhdplus.py
@@ -106,7 +106,7 @@ IV_riv_tot_id=[]
 with open(rrr_con_file,'rb') as csvfile:
      csvreader=csv.reader(csvfile)
      for row in csvreader:
-          IV_riv_tot_id.append(int(row[0]))
+          IV_riv_tot_id.append(int(float(row[0])))
 IS_riv_tot1=len(IV_riv_tot_id)
 print('- Number of river reaches in rrr_con_file: '+str(IS_riv_tot1))
 
@@ -117,7 +117,7 @@ IV_riv_tot_sort=[]
 with open(rrr_srt_file,'rb') as csvfile:
      csvreader=csv.reader(csvfile)
      for row in csvreader:
-          IV_riv_tot_sort.append(int(row[0]))
+          IV_riv_tot_sort.append(int(float(row[0])))
 IS_riv_tot2=len(IV_riv_tot_sort)
 print('- Number of river reaches in rrr_srt_file: '+str(IS_riv_tot2))
 


### PR DESCRIPTION
whenever rrr tries to convert a string to an integer, it sometimes errors out because the string is actually a float (e.g. '2390.0'). this fixes that issue